### PR TITLE
Add missing id

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,7 +316,7 @@ resilient:
   </div>
 </article>
 
-<article class="flex height-viewport height-fit items-center m0 empower-impact border-thick border-dashed paint-1 ">
+<article id="bloat" class="flex height-viewport height-fit items-center m0 empower-impact border-thick border-dashed paint-1 ">
   <div class="flex flex-column m-auto">
 <pre class="weight-800"><code>
 .coupling {


### PR DESCRIPTION
`id` is needed for it to be arrowable. I named this one `bloat` for recall