### PR TITLE
aka overriding

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,9 +307,10 @@
   </div>
 </article>
 
-<article id="mutating" class="block-flex height-viewport height-fit items-center m0 empower-impact border-thick border-dashed paint-bee">
+<article id="overriding" class="block-flex height-viewport height-fit items-center m0 empower-impact border-thick border-dashed paint-bee">
   <div class="block-flex flex-column m-auto">
-    <p class="empower-proud p4 prose">If you define styles and then override them in another <b>context</b> or <b>module</b> then you are mutating them.
+    <h3 class="font-same empower-proud mb2"><abbr class="font-300">aka</abbr> <b>overriding</b></h3>
+    <p class="prose m0 font-400">across <b class="font-500">modules</b> or <b class="font-500">contexts</b>
   </div>
 </article>
 


### PR DESCRIPTION
Improve word economy based on [feedback](https://github.com/ryanve/resilient-css/issues/18)

> ### <abbr>aka</abbr> <b>overriding</b>
> across modules or contexts

