### PR TITLE
~temps~ tempts

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,7 +474,7 @@
   <div class="m-auto">
     <p class="prose">Coupling <b>depends</b> on sharing.
     <p class="prose">Coupling <b>affects</b> inheritance.
-    <p class="prose">Coupling <b>temps</b> mutation.
+    <p class="prose">Coupling <b>tempts</b> mutation.
   </div>
 </article>
 


### PR DESCRIPTION
Correct spelling. Intended word is *tempt*